### PR TITLE
chore: release v1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,37 @@
+## 1.0.0
+
+### Breaking Changes
+
+- **BREAKING**: Removed `hasSeparator` parameter. Use `format` or `formatString` parameters instead for more flexible number formatting control.
+
+  Migration guide:
+  ```dart
+  // Before
+  SmoothCounter(count: 1234, hasSeparator: false)
+
+  // After
+  SmoothCounter(count: 1234, formatString: '0')
+  ```
+
+### Features
+
+- **feat**: Added `format` parameter to accept `NumberFormat` instances for custom number formatting
+- **feat**: Added `formatString` parameter to specify number format patterns (e.g., `'#,##0.00'`, `'0'`)
+- **feat**: Support both `int` and `double` types for the `count` parameter
+
+### Improvements
+
+- **refactor**: Replaced internal `Formatter` class with direct `NumberFormat` integration from `intl` package
+- **refactor**: Removed unnecessary library declaration
+
+### Documentation
+
+- **docs**: Updated README with comprehensive number formatting examples
+- **docs**: Added documentation for `format` parameter in `SmoothCounter` and `SmoothCounterRow`
+- **docs**: Updated requirements to Dart 3.8.0+ and Flutter 3.32.0+
+- **docs**: Added prefix/suffix feature documentation
+- **docs**: Changed examples to use `double` type to demonstrate decimal support
+
 ## 0.3.0
 
 ### Dependencies

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,7 @@
 name: smooth_counter
 description: A Flutter package that is a smooth running counter widget.
-version: 0.3.0
+version: 1.0.0
+homepage: https://github.com/KyoheiG3/smooth_counter
 repository: https://github.com/KyoheiG3/smooth_counter
 documentation: https://github.com/KyoheiG3/smooth_counter
 issue_tracker: https://github.com/KyoheiG3/smooth_counter/issues


### PR DESCRIPTION
## Overview
This PR prepares the v1.0.0 release with updated CHANGELOG and version bump. This is a major version release that includes breaking changes from the NumberFormat integration refactoring.

## Changes
- Updated version to 1.0.0 in pubspec.yaml
- Added v1.0.0 section to CHANGELOG.md with complete release notes
- Added homepage field to pubspec.yaml

### Release Highlights (v1.0.0)

**Breaking Changes:**
- Removed `hasSeparator` parameter in favor of `format` and `formatString` parameters

**New Features:**
- Added `format` parameter to accept `NumberFormat` instances
- Added `formatString` parameter for pattern-based formatting
- Support for both `int` and `double` types

**Improvements:**
- Replaced internal `Formatter` class with direct `NumberFormat` integration
- Comprehensive documentation updates

## Test Instructions
1. Review the CHANGELOG.md to ensure all changes are accurately documented
2. Verify the version number is correctly updated to 1.0.0 in pubspec.yaml
3. Confirm that the breaking changes and migration guide are clearly documented

## References
- Based on PR #8 (NumberFormat integration)
- Follows semantic versioning conventions
- Breaking changes warrant major version bump to 1.0.0